### PR TITLE
fix: solves unwanted unmount of wrapped components

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -213,15 +213,17 @@ export class ResponsiveProps extends Component {
 /** HOC props proxy for dealing with responsive props. */
 /* Enhances a styled component with the props responsiveProps
  */
+const ThemedResponsiveProps = withTheme(ResponsiveProps);
+
 const withResponsiveProps = (WrappedComponent, mixins = {}) => {
-  return React.forwardRef((props, ref) =>
-    React.createElement(withTheme(ResponsiveProps), {
-      forwardRef: ref,
-      wrappedComponent: WrappedComponent,
-      mixins,
-      ...props
-    })
-  );
+  return React.forwardRef((props, ref) => (
+    <ThemedResponsiveProps
+      forwardRef={ref}
+      wrappedComponent={WrappedComponent}
+      mixins={mixins}
+      {...props}
+    />
+  ));
 };
 
 withResponsiveProps.displayName = "responsiveProps";


### PR DESCRIPTION
When withResponsiveProps invokes React.createElement, the first argument is
withTheme(ResponsiveProps), this is always a new component. React cleans
up this component when props change and mounts it again. Visually it is
hard to notice the error, as very few DOM changes happen,depending on
the setting. However this is noticeable with components running effects
or life cycles.

Simply declaring `const ThemedResponsiveProps = withTheme(ResponsiveProps)` helps, but I also removed the `React.createElement` in favor or natural JSX. 

I've also added a test, which fails under the current implementation.

I've also put together a demonstration for both the fix and the standing issue: https://codesandbox.io/s/withresponsiveprops-bug-and-fix-yqk94

Thanks for the awesome job!